### PR TITLE
Discarding the master-slave phrasing

### DIFF
--- a/edssdk/edssdk/edsConfig.py
+++ b/edssdk/edssdk/edsConfig.py
@@ -29,9 +29,9 @@ class edsConfig:
 
         self.hadoop_setting = {}
         self.hadoop_setting['cluster_type'] = None
-        self.hadoop_setting['master_type'] = None
-        self.hadoop_setting['slave_type'] = None
-        self.hadoop_setting['slave_num'] = 0
+        self.hadoop_setting['main_type'] = None
+        self.hadoop_setting['subordinate_type'] = None
+        self.hadoop_setting['subordinate_num'] = 0
         
         self.command_setting = {}
         self.command_setting['id'] = None

--- a/edssdk/test_edssdk.py
+++ b/edssdk/test_edssdk.py
@@ -23,8 +23,8 @@ def create():
     conf.name = 'test edssdk'
 #    conf.cloud_setting['region'] = 'cn-hangzhou'
 #    conf.cloud_setting['zone'] = 'cn-hangzhou-a'
-    conf.hadoop_setting['master_type'] = 'ecs.s2.large'
-    conf.hadoop_setting['slave_type'] = 'ecs.s2.large'
+    conf.hadoop_setting['main_type'] = 'ecs.s2.large'
+    conf.hadoop_setting['subordinate_type'] = 'ecs.s2.large'
     r = cluster.create(conf.getJson())
     if not r.ok:
         print 'requests post error'


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.